### PR TITLE
Add clarity-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "stacks-test-tools",
+  "version": "1.0.0",
+  "description": "Repository to hold defaults such as CONTRIBUTING, CODE_OF_CONDUCT and LICENSE (MIT)",
+  "main": "index.ts",
+  "scripts": {
+    "test": "vitest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/stacks-network/stacks-test-tools.git"
+  },
+  "keywords": [
+    "stacks",
+    "blockchain",
+    "clarity",
+    "clarinet"
+  ],
+  "author": "friedger",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/stacks-network/stacks-test-tools/issues"
+  },
+  "homepage": "https://github.com/stacks-network/stacks-test-tools#readme",
+  "dependencies": {
+    "vitest": "^1.1.0"
+  }
+}

--- a/packages/clarity-testing/.gitignore
+++ b/packages/clarity-testing/.gitignore
@@ -1,0 +1,9 @@
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules
+*.log.txt
+history.txt

--- a/packages/clarity-testing/Clarinet.toml
+++ b/packages/clarity-testing/Clarinet.toml
@@ -1,0 +1,6 @@
+
+[project]
+name = "core-contracts"
+
+[repl]
+costs_version = 1

--- a/packages/clarity-testing/package-lock.json
+++ b/packages/clarity-testing/package-lock.json
@@ -1,0 +1,1773 @@
+{
+  "name": "clarity-testing",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clarity-testing",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hirosystems/clarinet-sdk": "^1.2.0",
+        "@stacks/transactions": "^6.11.0",
+        "fs": "^0.0.1-security",
+        "path": "^0.12.7",
+        "vitest": "^1.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.10.tgz",
+      "integrity": "sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.10.tgz",
+      "integrity": "sha512-7W0bK7qfkw1fc2viBfrtAEkDKHatYfHzr/jKAHNr9BvkYDXPcC6bodtm8AyLJNNuqClLNaeTLuwURt4PRT9d7w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.10.tgz",
+      "integrity": "sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.10.tgz",
+      "integrity": "sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.10.tgz",
+      "integrity": "sha512-YSRRs2zOpwypck+6GL3wGXx2gNP7DXzetmo5pHXLrY/VIMsS59yKfjPizQ4lLt5vEI80M41gjm2BxrGZ5U+VMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.10.tgz",
+      "integrity": "sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.10.tgz",
+      "integrity": "sha512-dMtk1wc7FSH8CCkE854GyGuNKCewlh+7heYP/sclpOG6Cectzk14qdUIY5CrKDbkA/OczXq9WesqnPl09mj5dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.10.tgz",
+      "integrity": "sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.10.tgz",
+      "integrity": "sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.10.tgz",
+      "integrity": "sha512-QxaouHWZ+2KWEj7cGJmvTIHVALfhpGxo3WLmlYfJ+dA5fJB6lDEIg+oe/0//FuyVHuS3l79/wyBxbHr0NgtxJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.10.tgz",
+      "integrity": "sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.10.tgz",
+      "integrity": "sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.10.tgz",
+      "integrity": "sha512-J4gH3zhHNbdZN0Bcr1QUGVNkHTdpijgx5VMxeetSk6ntdt+vR1DqGmHxQYHRmNb77tP6GVvD+K0NyO4xjd7y4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.10.tgz",
+      "integrity": "sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.10.tgz",
+      "integrity": "sha512-0f/spw0PfBMZBNqtKe5FLzBDGo0SKZKvMl5PHYQr3+eiSscfJ96XEknCe+JoOayybWUFQbcJTrk946i3j9uYZA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.10.tgz",
+      "integrity": "sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.10.tgz",
+      "integrity": "sha512-SpYNEqg/6pZYoc+1zLCjVOYvxfZVZj6w0KROZ3Fje/QrM3nfvT2llI+wmKSrWuX6wmZeTapbarvuNNK/qepSgA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-PxcgvjdSjtgPMiPQrM3pwSaG4kGphP+bLSb+cihuP0LYdZv1epbAIecHVl5sD3npkfYBZ0ZnOjR878I7MdJDFg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.10.tgz",
+      "integrity": "sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.10.tgz",
+      "integrity": "sha512-+Sa4oTDbpBfGpl3Hn3XiUe4f8TU2JF7aX8cOfqFYMMjXp6ma6NJDztl5FDG8Ezx0OjwGikIHw+iA54YLDNNVfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.10.tgz",
+      "integrity": "sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.10.tgz",
+      "integrity": "sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@hirosystems/clarinet-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-1.2.0.tgz",
+      "integrity": "sha512-O0Gyh3pwwOVJTbLlxHG6vSB/KXr+U/nZzd2kpubQO4Qqxjn5/vo8l8J+/fwKOxhzM4QOa42M1sCaVZSB/PkTFg==",
+      "dependencies": {
+        "@hirosystems/clarinet-sdk-wasm": "^1.2.0",
+        "@stacks/transactions": "^6.9.0",
+        "kolorist": "^1.8.0",
+        "prompts": "^2.4.2",
+        "vitest": "^1.0.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "clarinet-sdk": "dist/cjs/bin/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hirosystems/clarinet-sdk-wasm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-1.2.0.tgz",
+      "integrity": "sha512-TnJ243lEgIqHSIeMdEHi1hJceFBJ5mWfjfXv86GKaoyVOS6yX1vGL2a6ZuVO9FfWPNxsiSvaQV/FndVuansAVQ=="
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
+      "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
+      "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
+      "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
+      "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
+      "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
+      "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
+      "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
+      "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
+      "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
+      "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
+      "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
+      "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
+      "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+    },
+    "node_modules/@stacks/common": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.10.0.tgz",
+      "integrity": "sha512-6x5Z7AKd9/kj3+DYE9xIDIkFLHihBH614i2wqrZIjN02WxVo063hWSjIlUxlx8P4gl6olVzlOy5LzhLJD9OP0A==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "@types/node": "^18.0.4"
+      }
+    },
+    "node_modules/@stacks/network": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.10.0.tgz",
+      "integrity": "sha512-mbiZ8nlsyy77ndmBdaqhHXii22IFdK4ThRcOQs9j/O00DkAr04jCM4GV5Q+VLUnZ9OBoJq7yOV7Pf6jglh+0hw==",
+      "dependencies": {
+        "@stacks/common": "^6.10.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/transactions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.11.0.tgz",
+      "integrity": "sha512-+zIDqn9j4H/+o1ER8C9rFpig1fyrQcj2hVGNIrp+YbpPyja+cxv3fPk6kI/gePzwggzxRgUkIWhBc+mZAXuXyQ==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^6.10.0",
+        "@stacks/network": "^6.10.0",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.1.0.tgz",
+      "integrity": "sha512-9IE2WWkcJo2BR9eqtY5MIo3TPmS50Pnwpm66A6neb2hvk/QSLfPXBz2qdiwUOQkwyFuuXEUj5380CbwfzW4+/w==",
+      "dependencies": {
+        "@vitest/spy": "1.1.0",
+        "@vitest/utils": "1.1.0",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.1.0.tgz",
+      "integrity": "sha512-zdNLJ00pm5z/uhbWF6aeIJCGMSyTyWImy3Fcp9piRGvueERFlQFbUwCpzVce79OLm2UHk9iwaMSOaU9jVHgNVw==",
+      "dependencies": {
+        "@vitest/utils": "1.1.0",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.1.0.tgz",
+      "integrity": "sha512-5O/wyZg09V5qmNmAlUgCBqflvn2ylgsWJRRuPrnHEfDNT6tQpQ8O1isNGgo+VxofISHqz961SG3iVvt3SPK/QQ==",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.1.0.tgz",
+      "integrity": "sha512-sNOVSU/GE+7+P76qYo+VXdXhXffzWZcYIPQfmkiRxaNCSPiLANvQx5Mx6ZURJ/ndtEkUJEpvKLXqAYTKEY+lTg==",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-z+s510fKmYz4Y41XhNs3vcuFTFhcij2YF7F8VQfMEYAAUfqQh0Zfg7+w9xdgFGhPf3tX3TicAe+8BDITk6ampQ==",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/c32check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
+      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "base-x": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.10.tgz",
+      "integrity": "sha512-S1Y27QGt/snkNYrRcswgRFqZjaTG5a5xM3EQo97uNBnH505pdzSNe/HLBq1v0RO7iK/ngdbhJB6mDAp0OK+iUA==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.10",
+        "@esbuild/android-arm": "0.19.10",
+        "@esbuild/android-arm64": "0.19.10",
+        "@esbuild/android-x64": "0.19.10",
+        "@esbuild/darwin-arm64": "0.19.10",
+        "@esbuild/darwin-x64": "0.19.10",
+        "@esbuild/freebsd-arm64": "0.19.10",
+        "@esbuild/freebsd-x64": "0.19.10",
+        "@esbuild/linux-arm": "0.19.10",
+        "@esbuild/linux-arm64": "0.19.10",
+        "@esbuild/linux-ia32": "0.19.10",
+        "@esbuild/linux-loong64": "0.19.10",
+        "@esbuild/linux-mips64el": "0.19.10",
+        "@esbuild/linux-ppc64": "0.19.10",
+        "@esbuild/linux-riscv64": "0.19.10",
+        "@esbuild/linux-s390x": "0.19.10",
+        "@esbuild/linux-x64": "0.19.10",
+        "@esbuild/netbsd-x64": "0.19.10",
+        "@esbuild/openbsd-x64": "0.19.10",
+        "@esbuild/sunos-x64": "0.19.10",
+        "@esbuild/win32-arm64": "0.19.10",
+        "@esbuild/win32-ia32": "0.19.10",
+        "@esbuild/win32-x64": "0.19.10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
+      "integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
+      "dependencies": {
+        "acorn": "^8.10.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q=="
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
+      "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.9.1",
+        "@rollup/rollup-android-arm64": "4.9.1",
+        "@rollup/rollup-darwin-arm64": "4.9.1",
+        "@rollup/rollup-darwin-x64": "4.9.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.1",
+        "@rollup/rollup-linux-arm64-musl": "4.9.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-musl": "4.9.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.1",
+        "@rollup/rollup-win32-x64-msvc": "4.9.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
+    "node_modules/std-env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+      "integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg=="
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "dependencies": {
+        "acorn": "^8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
+      "integrity": "sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg=="
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.1.tgz",
+      "integrity": "sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
+      "integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+      "dependencies": {
+        "esbuild": "^0.19.3",
+        "postcss": "^8.4.32",
+        "rollup": "^4.2.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.1.0.tgz",
+      "integrity": "sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.1.0.tgz",
+      "integrity": "sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==",
+      "dependencies": {
+        "@vitest/expect": "1.1.0",
+        "@vitest/runner": "1.1.0",
+        "@vitest/snapshot": "1.1.0",
+        "@vitest/spy": "1.1.0",
+        "@vitest/utils": "1.1.0",
+        "acorn-walk": "^8.3.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^1.3.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.1",
+        "vite": "^5.0.0",
+        "vite-node": "1.1.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "^1.0.0",
+        "@vitest/ui": "^1.0.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/clarity-testing/package.json
+++ b/packages/clarity-testing/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "clarity-testing",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "vitest"
+  },
+  "author": "friedger",
+  "license": "MIT",
+  "dependencies": {
+    "@hirosystems/clarinet-sdk": "^1.2.0",
+    "@stacks/transactions": "^6.11.0",
+    "fs": "^0.0.1-security",
+    "path": "^0.12.7",
+    "vitest": "^1.1.0",
+    "chokidar-cli": "^3.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vitest-environment-clarinet": "^1.0.0"
+  }
+}

--- a/packages/clarity-testing/src/parser/clar-flow.test.ts
+++ b/packages/clarity-testing/src/parser/clar-flow.test.ts
@@ -1,0 +1,175 @@
+import { ParsedTransactionResult, tx } from "@hirosystems/clarinet-sdk";
+import * as fs from "fs";
+import path from "path";
+import { describe, it } from "vitest";
+import {
+  CallInfo,
+  FunctionAnnotations,
+  FunctionBody,
+  extractTestAnnotationsAndCalls,
+} from "./utils/clarity-parser-flow-tests";
+import { expectOk, isValidTestFunction } from "./utils/test-helpers";
+
+/**
+ * Returns true if the contract is a test contract using the flow convention
+ * @param contractName name of the contract
+ * @returns
+ */
+function isTestContract(contractName: string) {
+  return contractName.substring(contractName.length - 10) === "_flow_test";
+}
+
+const accounts = simnet.getAccounts();
+clearLogFile();
+
+// for each test contract create a test suite
+simnet.getContractsInterfaces().forEach((contract, contractFQN) => {
+  if (!isTestContract(contractFQN)) {
+    return;
+  }
+
+  describe(contractFQN, () => {
+    // determine whether the contract has a prepare function
+    const hasDefaultPrepareFunction =
+      contract.functions.findIndex((f) => f.name === "prepare") >= 0;
+
+    contract.functions.forEach((functionCall) => {
+      if (!isValidTestFunction(functionCall)) {
+        return;
+      }
+
+      const functionName = functionCall.name;
+      const source = simnet.getContractSource(contractFQN)!;
+      const [annotations, functionBodies] =
+        extractTestAnnotationsAndCalls(source);
+      const functionAnnotations: FunctionAnnotations =
+        annotations[functionName] || {};
+      const testname = `${functionCall.name}${
+        functionAnnotations.name ? `: ${functionAnnotations.name}` : ""
+      }`;
+      it(testname, () => {
+        writeToLogFile(`\n\n${testname}\n\n`);
+        if (hasDefaultPrepareFunction && !functionAnnotations.prepare)
+          functionAnnotations.prepare = "prepare";
+        if (functionAnnotations["no-prepare"])
+          delete functionAnnotations.prepare;
+
+        const functionBody = functionBodies[functionName] || [];
+
+        mineBlocksFromFunctionBody(contractFQN, functionName, functionBody);
+      });
+    });
+  });
+});
+
+/**
+ * Mines one or more blocks based on the functions calls in the test function.
+ * The function body must be one of the following:
+ * 1. (unwrap! (contract-call? .contract-name function-name args))
+ * 2. (try! (function-name))
+ *
+ * @param contractFQN the contract id
+ * @param testFunctionName the name of the test function containing calls
+ * @param calls a list of function calls with annotations part of the test function body
+ */
+function mineBlocksFromFunctionBody(
+  contractFQN: string,
+  testFunctionName: string,
+  calls: FunctionBody
+) {
+  let blockStarted = false;
+  let txs: any[] = [];
+  let block: ParsedTransactionResult[] = [];
+
+  // go through all function calls and
+  // bundle function them into blocks
+  for (const { callAnnotations, callInfo } of calls) {
+    // mine empty blocks
+    const mineBlocksBefore =
+      parseInt(callAnnotations["mine-blocks-before"] as string) || 0;
+    // get caller address
+    const caller = accounts.get(
+      (callAnnotations["caller"] as string) || "deployer"
+    )!;
+
+    if (mineBlocksBefore >= 1) {
+      if (blockStarted) {
+        writeToLogFile(txs);
+        // mine block with txs and assert ok on all of them
+        block = simnet.mineBlock(txs);
+        for (let index = 0; index < txs.length; index++) {
+          expectOk(block, contractFQN, testFunctionName, index);
+        }
+        txs = [];
+        blockStarted = false;
+      }
+      // mine empty blocks if necessary
+      if (mineBlocksBefore > 1) {
+        simnet.mineEmptyBlocks(mineBlocksBefore - 1);
+        writeToLogFile(mineBlocksBefore - 1);
+      }
+    }
+    // start a new block if necessary
+    if (!blockStarted) {
+      blockStarted = true;
+    }
+    // add tx to current block
+    txs.push(generateCallWithArguments(callInfo, contractFQN, caller));
+  }
+  // close final block
+  if (blockStarted) {
+    writeToLogFile(txs);
+    block = simnet.mineBlock(txs);
+    for (let index = 0; index < txs.length; index++) {
+      expectOk(block, contractFQN, testFunctionName, index);
+    }
+    txs = [];
+    blockStarted = false;
+  }
+}
+
+/**
+ * creates a Tx
+ * @param callInfo
+ * @param contractPrincipal
+ * @param callerAddress
+ * @returns
+ */
+function generateCallWithArguments(
+  callInfo: CallInfo,
+  contractPrincipal: string,
+  callerAddress: string
+) {
+  const contractName = callInfo.contractName || contractPrincipal;
+  const functionName = callInfo.functionName;
+
+  return tx.callPublicFn(
+    contractName,
+    functionName,
+    callInfo.args.map((arg) => arg.value),
+    callerAddress
+  );
+}
+
+/**
+ * writes data to a log file that represents the sequence of blocks mined
+ * @param data
+ */
+function writeToLogFile(data: ParsedTransactionResult[] | number | string) {
+  const filePath = path.join(__dirname, "clar-flow-test.log.txt");
+  if (typeof data === "number") {
+    fs.appendFileSync(filePath, `${data} empty blocks\n`);
+  } else if (typeof data === "string") {
+    fs.appendFileSync(filePath, `${data}\n`);
+  } else {
+    fs.appendFileSync(filePath, `block:\n${JSON.stringify(data, null, 2)}\n`);
+  }
+}
+
+/**
+ * clears the log file
+ */
+function clearLogFile() {
+  const filePath = path.join(__dirname, "clar-flow-test.log.txt");
+  fs.writeFileSync(filePath, "");
+}

--- a/packages/clarity-testing/src/parser/clar.test.ts
+++ b/packages/clarity-testing/src/parser/clar.test.ts
@@ -1,0 +1,155 @@
+import { tx } from "@hirosystems/clarinet-sdk";
+import { describe, it } from "vitest";
+import {
+  extractTestAnnotations,
+} from "./clarity-parser";
+import { expectOkTrue, isValidTestFunction } from "./test-helpers";
+
+/**
+ * Returns true if the contract is a test contract
+ * @param contractName name of the contract
+ * @returns 
+ */
+function isTestContract(contractName: string) {
+  return (
+    contractName.substring(contractName.length - 5) === "_test" &&
+    contractName.substring(contractName.length - 10) !== "_flow_test"
+  );
+}
+
+const accounts = simnet.getAccounts();
+
+// for each test contract create a test suite
+simnet.getContractsInterfaces().forEach((contract, contractFQN) => {
+  if (!isTestContract(contractFQN)) {
+    return;
+  }
+
+  describe(contractFQN, () => {
+    // determine whether the contract has a prepare function
+    const hasDefaultPrepareFunction =
+      contract.functions.findIndex((f) => f.name === "prepare") >= 0;
+
+    contract.functions.forEach((functionCall) => {
+      if (!isValidTestFunction(functionCall)) {
+        return;
+      }
+
+      const functionName = functionCall.name;
+      const source = simnet.getContractSource(contractFQN)!;
+      const annotations: any = extractTestAnnotations(source);
+      const functionAnnotations: FunctionAnnotations =
+        annotations[functionName] || {};
+
+      const mineBlocksBefore =
+        parseInt(annotations["mine-blocks-before"] as string) || 0;
+
+      const testDescription = `${functionCall.name}${
+        functionAnnotations.name ? `: ${functionAnnotations.name}` : ""
+      }`;
+      it(testDescription, () => {
+        // handle prepare function for this test
+        if (hasDefaultPrepareFunction && !functionAnnotations.prepare)
+          functionAnnotations.prepare = "prepare";
+        if (functionAnnotations["no-prepare"])
+          delete functionAnnotations.prepare;
+
+        // handle caller address for this test
+        const callerAddress = functionAnnotations.caller
+          ? annotations.caller[0] === "'"
+            ? `${(annotations.caller as string).substring(1)}`
+            : accounts.get(annotations.caller)!
+          : accounts.get("deployer")!;
+
+        if (functionAnnotations.prepare) {
+          // mine block with prepare function call
+          mineBlockWithPrepareAndTestFunctionCall(
+            contractFQN,
+            functionAnnotations.prepare as string,
+            mineBlocksBefore,
+            functionName,
+            callerAddress
+          );
+        } else {
+          // mine block without prepare function call
+          mineBlockWithTestFunctionCall(
+            contractFQN,
+            mineBlocksBefore,
+            functionName,
+            callerAddress
+          );
+        }
+      });
+    });
+  });
+});
+
+/**
+ * Mine a block with a prepare function call and a test function call
+ * If requested, mine the specified number of blocks beforehand.
+ * @param contractFQN the contract id of the test
+ * @param prepareFunctionName the function name of the prepare function
+ * @param mineBlocksBefore the number of blocks to mine before the prepare function call, can be 0
+ * @param functionName the test function name
+ * @param callerAddress the caller of the test function
+ */
+function mineBlockWithPrepareAndTestFunctionCall(
+  contractFQN: string,
+  prepareFunctionName: string,
+  mineBlocksBefore: number,
+  functionName: string,
+  callerAddress: string
+) {
+  if (mineBlocksBefore > 0) {
+    let block = simnet.mineBlock([
+      tx.callPublicFn(
+        contractFQN,
+        prepareFunctionName,
+        [],
+        accounts.get("deployer")!
+      ),
+    ]);
+    expectOkTrue(block, contractFQN, prepareFunctionName, 0);
+    simnet.mineEmptyBlocks(mineBlocksBefore - 1);
+
+    block = simnet.mineBlock([
+      tx.callPublicFn(contractFQN, functionName, [], callerAddress),
+    ]);
+
+    expectOkTrue(block, contractFQN, functionName, 0);
+  } else {
+    let block = simnet.mineBlock([
+      tx.callPublicFn(
+        contractFQN,
+        prepareFunctionName,
+        [],
+        accounts.get("deployer")!
+      ),
+      tx.callPublicFn(contractFQN, functionName, [], callerAddress),
+    ]);
+    expectOkTrue(block, contractFQN, prepareFunctionName, 0);
+    expectOkTrue(block, contractFQN, functionName, 1);
+  }
+}
+
+/**
+ * Mines a block with a single test function call
+ * If requested, mine the specified number of blocks beforehand.
+ *
+ * @param contractFQN the contract id of the test
+ * @param mineBlocksBefore the number of blocks to mine before the test function call, can be 0
+ * @param functionName the test function name
+ * @param callerAddress the caller of the test function
+ */
+function mineBlockWithTestFunctionCall(
+  contractFQN: string,
+  mineBlocksBefore: number,
+  functionName: string,
+  callerAddress: string
+) {
+  simnet.mineEmptyBlocks(mineBlocksBefore);
+  const block = simnet.mineBlock([
+    tx.callPublicFn(contractFQN, functionName, [], callerAddress),
+  ]);
+  expectOkTrue(block, contractFQN, functionName, 0);
+}

--- a/packages/clarity-testing/src/parser/clarity-parser-flow-tests.ts
+++ b/packages/clarity-testing/src/parser/clarity-parser-flow-tests.ts
@@ -1,0 +1,201 @@
+import { ClarityValue } from "@stacks/transactions";
+import { stringToCV } from "./string-to-cv";
+export type FunctionAnnotations = { [key: string]: string | boolean };
+export type FunctionBody = {
+  callAnnotations: FunctionAnnotations[];
+  callInfo: CallInfo;
+}[];
+
+export type ContractCall = {
+  callAnnotations: FunctionAnnotations;
+  callInfo: CallInfo;
+};
+
+export type CallInfo = {
+  contractName: string;
+  functionName: string;
+  args: { type: string; value: ClarityValue }[];
+};
+
+const functionRegex =
+  /^([ \t]{0,};;[ \t]{0,}@[^()]+?)\n[ \t]{0,}\(define-public[\s]+\((.+?)[ \t|)]/gm;
+const annotationsRegex = /^;;[ \t]{1,}@([a-z-]+)(?:$|[ \t]+?(.+?))$/;
+
+const callRegex =
+  /\n*^([ \t]{0,};;[ \t]{0,}@[\s\S]+?)\n[ \t]{0,}(\((?:[^()]*|\((?:[^()]*|\([^()]*\))*\))*\))/gm;
+
+/**
+ * Parser function for flow unit tests.
+ *
+ * Flow unit tests can be used for tx calls where
+ * the tx-sender should be equal to the contract-caller.
+ *
+ * Takes the whole contract source and returns an object containing
+ * the function annotations and function bodies for each function.
+ * @param contractSource
+ * @returns
+ */
+export function extractTestAnnotationsAndCalls(contractSource: string) {
+  const functionAnnotations: any = {};
+  const functionBodies: any = {};
+  contractSource = contractSource.replace(/\r/g, "");
+  const matches1 = contractSource.matchAll(functionRegex);
+
+  let indexStart: number = -1;
+  let headerLength: number = 0;
+  let indexEnd: number = -1;
+  let lastFunctionName: string = "";
+  let contractCalls: {
+    callAnnotations: FunctionAnnotations;
+    callInfo: CallInfo;
+  }[];
+  for (const [functionHeader, comments, functionName] of matches1) {
+    if (functionName.substring(0, 5) !== "test-") continue;
+    functionAnnotations[functionName] = {};
+    const lines = comments.split("\n");
+    for (const line of lines) {
+      const [, prop, value] = line.match(annotationsRegex) || [];
+      if (prop) functionAnnotations[functionName][prop] = value ?? true;
+    }
+    if (indexStart < 0) {
+      indexStart = contractSource.indexOf(functionHeader);
+      headerLength = functionHeader.length;
+      lastFunctionName = functionName;
+    } else {
+      indexEnd = contractSource.indexOf(functionHeader);
+      const lastFunctionBody = contractSource.substring(
+        indexStart + headerLength,
+        indexEnd
+      );
+
+      // add contracts calls in functions body for last function
+      contractCalls = extractContractCalls(lastFunctionBody);
+
+      functionBodies[lastFunctionName] = contractCalls;
+      indexStart = indexEnd;
+      headerLength = functionHeader.length;
+      lastFunctionName = functionName;
+    }
+  }
+  const lastFunctionBody = contractSource.substring(indexStart + headerLength);
+  contractCalls = extractContractCalls(lastFunctionBody);
+  functionBodies[lastFunctionName] = contractCalls;
+
+  return [functionAnnotations, functionBodies];
+}
+
+/**
+ * Takes a string and returns an array of objects containing
+ * the call annotations and call info within the function body.
+ *
+ * The function body should look like this
+ * (begin
+ *   ... lines of code..
+ *   (ok true))
+ *
+ * Only two lines of code are accepted:
+ * 1. (unwrap! (contract-call? .contract-name function-name args))
+ * 2. (try! (function-name))
+ * @param lastFunctionBody
+ * @returns
+ */
+export function extractContractCalls(lastFunctionBody: string) {
+  const calls = lastFunctionBody.matchAll(callRegex);
+  const contractCalls: ContractCall[] = [];
+  for (const [, comments, call] of calls) {
+    const callAnnotations: FunctionAnnotations = {};
+    const lines = comments.split("\n");
+    for (const line of lines) {
+      const [, prop, value] = line.trim().match(annotationsRegex) || [];
+      if (prop) callAnnotations[prop] = value ?? true;
+    }
+    // try to extract call info from (unwrap! (contract-call? ...))
+    let callInfo = extractUnwrapInfo(call);
+    if (!callInfo) {
+      // try to extract call info from (try! (my-function))
+      callInfo = extractCallInfo(call);
+    }
+    if (callInfo) {
+      contractCalls.push({ callAnnotations, callInfo });
+    } else {
+      throw new Error(`Could not extract call info from ${call}`);
+    }
+  }
+  return contractCalls;
+}
+
+/**
+ * handle (unwrap! (contract-call? ...)) statements
+ * @param statement 
+ * @returns 
+ */
+function extractUnwrapInfo(statement: string): CallInfo | null {
+  const match = statement.match(
+    /\(unwrap! \(contract-call\? \.(.+?) (.+?)(( .+?)*)\)/
+  );
+  if (!match) return null;
+
+  const contractName = match[1];
+  const functionName = match[2];
+  const argStrings = splitArgs(match[3]);
+  let fn: any;
+  simnet.getContractsInterfaces().forEach((contract, contractFQN) => {
+    const [_, ctrName] = contractFQN.split(".");
+    if (ctrName === contractName) {
+      fn = contract.functions.find((f) => f.name === functionName);
+      if (!fn) {
+        throw `function ${functionName} not found in contract ${contractName}`;
+      }
+    }
+  });
+  if (!fn) {
+    throw `function ${functionName} not found in contract ${contractName}`;
+  }
+  const args = fn.args.map((arg: any, index: number) =>
+  stringToCV(argStrings[index], arg.type)
+  );
+
+  return {
+    contractName,
+    functionName,
+    args,
+  };
+}
+
+
+function extractCallInfo(statement: string) {
+  const match = statement.match(/\(try! \((.+?)\)\)/);
+  if (!match) return null;
+  return { contractName: "", functionName: match[1], args: [] };
+}
+
+
+
+// take a string containing function arguments and
+// split them correctly into an array of argument strings
+function splitArgs(argString: string): string[] {
+  const splitArgs: string[] = [];
+  let argStart = 0;
+  let brackets = 0; // curly brackets
+  let rbrackets = 0; // round brackets
+
+  for (let i = 0; i < argString.length; i++) {
+    const char = argString[i];
+
+    if (char === "{") brackets++;
+    if (char === "}") brackets--;
+    if (char === "(") rbrackets++;
+    if (char === ")") rbrackets--;
+
+    const atLastChar = i === argString.length - 1;
+    if ((char === " " && brackets === 0 && rbrackets === 0) || atLastChar) {
+      const newArg = argString.slice(argStart, i + (atLastChar ? 1 : 0));
+      if (newArg.trim()) {
+        splitArgs.push(newArg.trim());
+      }
+      argStart = i + 1;
+    }
+  }
+
+  return splitArgs;
+}

--- a/packages/clarity-testing/src/parser/clarity-parser.ts
+++ b/packages/clarity-testing/src/parser/clarity-parser.ts
@@ -1,0 +1,25 @@
+const functionRegex =
+  /^([ \t]{0,};;[ \t]{0,}@[^()]+?)\n[ \t]{0,}\(define-public[\s]+\((.+?)[ \t|)]/gm;
+const annotationsRegex = /^;;[ \t]{1,}@([a-z-]+)(?:$|[ \t]+?(.+?))$/;
+
+/**
+ * Parser function for normal unit tests.
+ *
+ * Takes the whole contract source and returns an object containing
+ * the function annotations for each function
+ * @param contractSource
+ * @returns
+ */
+export function extractTestAnnotations(contractSource: string) {
+  const functionAnnotations: any = {};
+  const matches = contractSource.replace(/\r/g, "").matchAll(functionRegex);
+  for (const [, comments, functionName] of matches) {
+    functionAnnotations[functionName] = {};
+    const lines = comments.split("\n");
+    for (const line of lines) {
+      const [, prop, value] = line.match(annotationsRegex) || [];
+      if (prop) functionAnnotations[functionName][prop] = value ?? true;
+    }
+  }
+  return functionAnnotations;
+}

--- a/packages/clarity-testing/src/parser/string-to-cv.ts
+++ b/packages/clarity-testing/src/parser/string-to-cv.ts
@@ -1,0 +1,129 @@
+import { hexToBytes } from "@stacks/common";
+import { Cl, ClarityValue } from "@stacks/transactions";
+import { buffer } from "@stacks/transactions/dist/cl";
+
+export type ContractInterfaceTupleEntryType = {
+  name: string;
+  type: ContractInterfaceAtomType;
+};
+
+export type ContractInterfaceAtomType =
+  | "none"
+  | "int128"
+  | "uint128"
+  | "bool"
+  | "principal"
+  | {
+      buffer: {
+        length: number;
+      };
+    }
+  | {
+      "string-utf8": {
+        length: number;
+      };
+    }
+  | {
+      "string-ascii": {
+        length: number;
+      };
+    }
+  | {
+      tuple: ContractInterfaceTupleEntryType[];
+    }
+  | {
+      optional: ContractInterfaceAtomType;
+    }
+  | {
+      response: {
+        ok: ContractInterfaceAtomType;
+        error: ContractInterfaceAtomType;
+      };
+    }
+  | {
+      list: {
+        type: ContractInterfaceAtomType;
+        length: number;
+      };
+    }
+  | "trait_reference";
+
+/**
+ * converts a string argument into a ClarityValue using the the type hint
+ * @param arg argument value as string
+ * @param type should be of type ContractInterfaceAtomType
+ * @returns
+ */
+export function stringToCV(
+  arg: string,
+  type: ContractInterfaceAtomType
+): { type: string; value: ClarityValue } {
+  switch (type) {
+    case "uint128":
+      return { type: "uint", value: Cl.uint(arg.slice(1)) };
+    case "int128":
+      return { type: "int", value: Cl.int(arg) };
+    case "principal":
+      const [address, name] = arg.split(".");
+      return name
+        ? { type: "principal", value: Cl.contractPrincipal(address, name) }
+        : { type: "principal", value: Cl.standardPrincipal(address) };
+    case "bool":
+      return { type: "bool", value: Cl.bool(arg === "true") };
+  }
+  const typeDescriptor = Object.keys(type)[0];
+  switch (typeDescriptor) {
+    case "buffer":
+      const hexValue = arg.toLowerCase().startsWith("0x") ? arg.slice(2) : arg;
+      return { type: "buffer", value: buffer(hexToBytes(hexValue)) };
+    case "string-utf8":
+      return { type: "string", value: Cl.stringUtf8(arg) };
+    case "string-ascii":
+      return { type: "string", value: Cl.stringAscii(arg) };
+    case "tuple":
+      return {
+        type: "tuple",
+        value: parseTuple(
+          arg,
+          (type as { tuple: ContractInterfaceTupleEntryType[] }).tuple
+        ),
+      };
+    case "optional":
+      if (arg === "none") {
+        return {
+          type: "none",
+          value: Cl.none(),
+        };
+      } else {
+        return {
+          type: "some",
+          value: Cl.some(
+            stringToCV(
+              arg,
+              (type as { optional: ContractInterfaceAtomType }).optional
+            ).value
+          ),
+        };
+      }
+    default:
+      throw new Error(`Unsupported type ${type}`);
+  }
+}
+
+function parseTuple(tupleString: string, tupleEntries: any): ClarityValue {
+  const tupleItems: { [key: string]: ClarityValue } = {};
+  tupleString
+    .slice(1, -1)
+    .split(",")
+    .map((item, index) => {
+      const [key, value] = item.split(":").map((s) => s.trim());
+      const uintMatch = value.match(/u(\d+)/);
+      if (uintMatch) {
+        tupleItems[key] = Cl.uint(uintMatch[1]);
+      } else {
+        tupleItems[key] = stringToCV(value, tupleEntries[index].type).value;
+      }
+    });
+
+  return Cl.tuple(tupleItems);
+}

--- a/packages/clarity-testing/src/parser/test-helpers.ts
+++ b/packages/clarity-testing/src/parser/test-helpers.ts
@@ -1,0 +1,62 @@
+import { ParsedTransactionResult } from "@hirosystems/clarinet-sdk";
+import { Cl, ClarityType, cvToString } from "@stacks/transactions";
+import { expect } from "vitest";
+
+/**
+ * checks whether the function is a valid test function starting with "test-"
+ * and not having any arguments
+ * @param functionCall
+ * @returns
+ */
+export function isValidTestFunction(functionCall: any) {
+  if (functionCall.name.startsWith("test-") && functionCall.args.length > 0) {
+    throw new Error("test functions must not have arguments");
+  }
+  return (
+    functionCall.name.startsWith("test-") && functionCall.args.length === 0
+  );
+}
+
+/**
+ * expect the result of tx index in the given block to be (ok true)
+ * @param block 
+ * @param contractFQN 
+ * @param functionName 
+ * @param index 
+ */
+export function expectOkTrue(
+  block: ParsedTransactionResult[],
+  contractFQN: string,
+  functionName: string,
+  index: number = 0
+) {
+  if (block[index].result.type === ClarityType.ResponseErr) {
+    console.log(cvToString(block[index].result));
+  }
+  expect(
+    block[index].result,
+    `${contractFQN}, ${functionName}, ${cvToString(block[index].result)}`
+  ).toBeOk(Cl.bool(true));
+}
+
+/**
+ * expect the result of tx index in the given block to be succesfull (ok ...)
+ * @param block 
+ * @param contractFQN 
+ * @param functionName 
+ * @param index 
+ */
+export function expectOk(
+  block: ParsedTransactionResult[],
+  contractFQN: string,
+  functionName: string,
+  index: number = 0
+) {
+  if (block[index].result.type === ClarityType.ResponseErr) {
+    console.log(cvToString(block[index].result));
+  }
+  expect(
+    block[index].result.type,
+    `${contractFQN}, ${functionName}, ${cvToString(block[index].result)}`
+  ).toBe(ClarityType.ResponseOk);
+}

--- a/packages/clarity-testing/tests/clarity-parser-flow.test.ts
+++ b/packages/clarity-testing/tests/clarity-parser-flow.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { extractTestAnnotationsAndCalls } from "../src/parser/clarity-parser-flow-tests";
+import { bufferCV } from "@stacks/transactions";
+
+describe("verify clarity parser for flow tests", () => {
+  it("should parse flow test with simple annotations", () => {
+    const [annotations, callInfos] = extractTestAnnotationsAndCalls(
+      fs.readFileSync(
+        path.join(__dirname, "./contracts/parser-tests/simple-flow.clar"),
+        "utf8"
+      )
+    );
+    expect(annotations["test-simple-flow"]).toEqual({});
+    // check the two function calls
+    expect(callInfos["test-simple-flow"][0]).toEqual({
+      callAnnotations: { caller: "wallet_1" },
+      callInfo: {
+        args: [],
+        contractName: "",
+        functionName: "my-test-function",
+      },
+    });
+    expect(callInfos["test-simple-flow"][1]).toEqual({
+      callAnnotations: { caller: "wallet_2" },
+      callInfo: {
+        args: [
+          { type: "buffer", value: bufferCV(new Uint8Array([])) },
+          { type: "buffer", value: bufferCV(new Uint8Array([])) },
+        ],
+        contractName: "bns",
+        functionName: "name-resolve",
+      },
+    });
+  });
+
+  it("should parse flow test with bad annotations", () => {
+    const [annotations, callInfos] = extractTestAnnotationsAndCalls(
+      fs.readFileSync(
+        path.join(__dirname, "./contracts/parser-tests/bad-flow.clar"),
+        "utf8"
+      )
+    );
+    expect(annotations["test-bad-flow"]).toEqual({});
+    expect(callInfos["test-bad-flow"][0]).toEqual({
+      callAnnotations: { caller: "wallet_1" },
+      callInfo: {
+        args: [],
+        contractName: "",
+        functionName: "my-test-function",
+      },
+    });
+    expect(callInfos["test-bad-flow"].length).toEqual(1);
+  });
+});

--- a/packages/clarity-testing/tests/clarity-parser-string-to-cv.test.ts
+++ b/packages/clarity-testing/tests/clarity-parser-string-to-cv.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { stringToCV } from "./utils/string-to-cv";
+import { ClarityType, intCV, stringUtf8CV, uintCV } from "@stacks/transactions";
+
+describe("verify string to cv conversion", () => {
+  it("should convert string to cv", () => {
+    const result = stringToCV("hello", { "string-utf8": { length: 100 } });
+    expect(result).toEqual({
+      type: "string",
+      value: stringUtf8CV("hello"),
+    });
+  });
+
+  it("should convert uint to cv", () => {
+    const result = stringToCV("u12345", "uint128");
+    expect(result).toEqual({
+      type: "uint",
+      value: uintCV(12345),
+    });
+  });
+
+  it("should convert tuple to cv", () => {
+    const result = stringToCV("{a: 12345}", {
+      tuple: [{ name: "a", type: "int128" }],
+    });
+    expect(result).toEqual({
+      type: "tuple",
+      value: { data: { a: intCV(12345) }, type: ClarityType.Tuple },
+    });
+  });
+});

--- a/packages/clarity-testing/tests/clarity-parser.test.ts
+++ b/packages/clarity-testing/tests/clarity-parser.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import path from "path";
+import { extractTestAnnotations } from "./utils/clarity-parser";
+
+describe("verify clarity parser", () => {
+  it("should parse without annotations", () => {
+    const result = extractTestAnnotations(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "../../contracts/parser-tests/no-annotations.clar"
+        ),
+        "utf8"
+      )
+    );
+    expect(result).toEqual({});
+  });
+
+  it("should parse with simple annotations", () => {
+    const result = extractTestAnnotations(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "../../contracts/parser-tests/simple-annotations.clar"
+        ),
+        "utf8"
+      )
+    );
+    expect(result["test-simple-annotations"]).toEqual({
+      name: "simple annotation test",
+    });
+  });
+
+  it("should parse with all annotations", () => {
+    const result = extractTestAnnotations(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "../../contracts/parser-tests/all-annotations.clar"
+        ),
+        "utf8"
+      )
+    );
+    expect(result["test-all-annotations-1"]).toEqual({
+      caller: "wallet_1",
+      description: "all annotation test",
+      "mine-before": "10",
+      name: "all annotation test",
+    });
+
+    expect(result["test-all-annotations-2"]).toEqual({
+      caller: "wallet_2",
+      description: "all annotation test 2",
+      "mine-before": "20",
+      name: "all annotation test 2",
+    });
+  });
+
+  it("should parse with bad annotations", () => {
+    const result = extractTestAnnotations(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "../../contracts/parser-tests/bad-annotations.clar"
+        ),
+        "utf8"
+      )
+    );
+    expect(result["test-bad-annotations"]).toEqual({
+      namexx: "bad annotation test",
+      callerxx: "wallet_1",
+      "mine-after": "10",
+    });
+  });
+});

--- a/packages/clarity-testing/tests/contracts/parser-tests/all-annotations.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/all-annotations.clar
@@ -1,0 +1,13 @@
+;; @name all annotation test
+;; @description all annotation test
+;; @mine-before 10
+;; @caller wallet_1
+(define-public (test-all-annotations-1)
+    (ok true))
+
+;; @name all annotation test 2
+;; @description all annotation test 2
+;; @mine-before 20
+;; @caller wallet_2
+(define-public (test-all-annotations-2)
+    (ok true))

--- a/packages/clarity-testing/tests/contracts/parser-tests/bad-annotations.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/bad-annotations.clar
@@ -1,0 +1,5 @@
+;; @namexx bad annotation test
+;; @mine-after 10
+;; @callerxx wallet_1
+(define-public (test-bad-annotations)
+    (ok false))

--- a/packages/clarity-testing/tests/contracts/parser-tests/bad-flow.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/bad-flow.clar
@@ -1,0 +1,12 @@
+;;@name bad annotation flow test
+(define-public (test-bad-flow)
+    (begin
+        ;; @caller wallet_1
+        (try! (my-test-function))
+        (unwrap! (contract-call? invalid-syntax))
+        (unwrap! (contract-call? .bns))
+        (ok true)))
+
+
+(define-private (my-test-function)
+    (ok true))

--- a/packages/clarity-testing/tests/contracts/parser-tests/no-annotations.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/no-annotations.clar
@@ -1,0 +1,2 @@
+(define-public (test-no-annotations)
+    (ok true))

--- a/packages/clarity-testing/tests/contracts/parser-tests/simple-annotations.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/simple-annotations.clar
@@ -1,0 +1,4 @@
+;; @name simple annotation test
+(define-public (test-simple-annotations)
+    ;; @mine-before is ignored here
+    (ok true))

--- a/packages/clarity-testing/tests/contracts/parser-tests/simple-flow.clar
+++ b/packages/clarity-testing/tests/contracts/parser-tests/simple-flow.clar
@@ -1,0 +1,11 @@
+;;@name simple flow test
+(define-public (test-simple-flow)
+    (begin
+        ;; @caller wallet_1
+        (try! (my-test-function))
+        ;; @caller wallet_2
+        (unwrap! (contract-call? .bns name-resolve 0x 0x))
+        (ok true)))
+
+(define-public (my-test-function)
+    (ok true))

--- a/packages/clarity-testing/tsconfig.json
+++ b/packages/clarity-testing/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "tests"
+  ]
+}


### PR DESCRIPTION
## Description

This PR adds a package that contains tools to write tests in clarity (instead of typescript).

## Testing information
1. `cd packages/clarity-testing`
2. `npm install`
3. `npm test`
