### PR TITLE
CI: Workflow to Publish to npm if Package Version is Changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/check-version-and-publish # TODO: remove this
 
 jobs:
   check_version_change:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: Publish Packages
+
+on: 
+  push:
+    branches:
+      - main
+      - ci/check-version-and-publish # TODO: remove this
+
+jobs:
+  check_version_change:
+    name: Check Version Changes
+    runs-on: ubuntu-latest
+    outputs:
+      CHANGED: ${{steps.check_version.outputs.changed}}
+      PACKAGE_PATH: ${{steps.set_path.outputs.changed_package_path}}
+    steps:
+      - name: Checkout Code
+        id: checkout_code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Set Path
+        id: set_path
+        run: |
+          # Get the paths of changed files
+          changes_paths=$(git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" | awk -F'/' '{print $1"/"$2}')
+
+          # Manifest names list
+          manifest_names=("package.json")
+
+          # Save the manifest path of the changed package in GitHub env and exit without error
+          for path in ${changes_paths}; do
+            if [[ $path == packages/* ]]; then
+              for manifest in "${manifest_names[@]}"; do
+                if [[ -f $path/$manifest ]]; then
+                  echo "changed_package_path=${path}" >> "$GITHUB_OUTPUT"
+                  echo "changed_manifest_path=${path}/${manifest}" >> "$GITHUB_OUTPUT"
+                  echo "package_changed=true" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+              done
+            fi
+          done
+
+          # If we haven't exited yet, no package was changed
+          echo "No package was changed in this commit!"
+          echo "package_changed=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check Version
+        id: check_version
+        if: ${{ steps.set_path.outputs.package_changed == 'true' }}
+        uses: EndBug/version-check@53c9309fefac91a21f852d5ca69f33878280d2f5 # v2.1.3
+        with:
+          file-name: ${{ steps.set_path.outputs.changed_manifest_path }}
+
+  publish_to_npm:
+    name: Publish Changed Package
+    runs-on: ubuntu-latest
+    needs: check_version_change
+    if: ${{ needs.check_version_change.outputs.CHANGED == 'true' }}
+    steps:
+      - name: Checkout Code
+        id: checkout_code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      
+      - name: Setup Node
+        id: setup_node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+      
+      - name: Publish Package
+        id: publish_package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: |
+          cd "$(echo '${{ needs.check_version_change.outputs.PACKAGE_PATH }}')"
+          npm ci
+          npm publish --access=public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       CHANGED: ${{steps.check_version.outputs.changed}}
-      PACKAGE_PATH: ${{steps.set_path.outputs.changed_package_path}}
+      PACKAGE_PATH: ${{steps.set_path.outputs.changed_path}}
     steps:
       - name: Checkout Code
         id: checkout_code
@@ -33,7 +33,7 @@ jobs:
             if [[ $path == packages/* ]]; then
               for manifest in "${manifest_names[@]}"; do
                 if [[ -f $path/$manifest ]]; then
-                  echo "changed_package_path=${path}" >> "$GITHUB_OUTPUT"
+                  echo "changed_path=${path}" >> "$GITHUB_OUTPUT"
                   echo "changed_manifest_path=${path}/${manifest}" >> "$GITHUB_OUTPUT"
                   echo "package_changed=true" >> "$GITHUB_OUTPUT"
                   exit 0
@@ -69,12 +69,18 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
-      
+
+      - name: Test Package
+        id: test_package
+        run: |
+          cd ${{ needs.check_version_change.outputs.PACKAGE_PATH }}
+          npm ci
+          npm test
+
       - name: Publish Package
         id: publish_package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        run: |
-          cd "$(echo '${{ needs.check_version_change.outputs.PACKAGE_PATH }}')"
-          npm ci
-          npm publish --access=public
+        uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
+        with:
+          token: ${{ secrets.NODE_AUTH_TOKEN }}
+          package: ${{ needs.check_version_change.outputs.PACKAGE_PATH }}
+          access: public


### PR DESCRIPTION
## Description

As per https://github.com/stacks-network/stacks-test-tools/issues/6, a workflow that automatically pushes packages to npm when it detects a version changed is a good addition, because some developers that update these packages might not have the permissions to publish themselves, and it makes their jobs easier by not having to worry about uploading the package once it's updated - that is now automated.

Closes #6

**Notes:**
- Prior to using this workflow, a repository secret named `NODE_AUTH_TOKEN` must be added, and it should contain the npm auth token of the `stacks` organisation (`Automation` type, so it can bypass `2FA`).
- The current workflow ONLY works with node packages. The workflow will have to be updated prior to any other type of package addition because otherwise it will fail every time a commit is made to that crate.
- The workflow currently uses the `--access=public` option for `npm publish` command because I couldn't test it with private packages. This will need a discussion with Jesse so I can properly update the command.

**Workflow runs:**
- Change package, not version (0 published to npm currently): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554751746
- Update version (failure due to package name - left it `@stacks/clarunit`): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554791139
- Update version (failure due to package visibility): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554829713
- Update version (1st publish to npm): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554873112
- Update package, not version: https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554905445
- Update package and version: https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554915725
- Add 2nd package (2nd publish to npm): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554946407
- Update version of 2nd package: https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554965295
- Update 2nd package, not version: https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554979305
- Add 3rd package (3rd publish to npm): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8554994122
- Change code in none of the packages: https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8555017431
- First commit to the source ~~commit~~ branch of this PR (added job names so it shows them instead of the ids): https://github.com/BowTiedDevOps/stacks-test-tools/actions/runs/8555076098

**NPM Profile (Published Packages):** https://www.npmjs.com/~bowtieddevops

Tag @wileyj and @hugocaillard because I can't add reviewers on this repo.