### PR TITLE
fix: use correct annotation object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ costs-reports.json
 node_modules
 *.log.txt
 history.txt
+.cache

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -24,6 +24,16 @@ path = "tests/contracts/generator-tests/contract-call_flow_test.clar"
 clarity_version = 3
 epoch = "3.1"
 
+[contracts.list-args_flow_test]
+path = "tests/contracts/generator-tests/list-args_flow_test.clar"
+clarity_version = 3
+epoch = "3.1"
+
+[contracts.some-contract]
+path = "tests/contracts/some-contract.clar"
+clarity_version = 3
+epoch = "3.1"
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -11,6 +11,11 @@ path = "tests/contracts/generator-tests/annotations_test.clar"
 clarity_version = 3
 epoch = "3.1"
 
+[contracts.annotations_flow_test]
+path = "tests/contracts/generator-tests/annotations_flow_test.clar"
+clarity_version = 3
+epoch = "3.1"
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -32,3 +32,11 @@ strict = false
 trusted_sender = false
 trusted_caller = false
 callee_filter = false
+
+
+[repl.remote_data]
+# Enable mainnet execution simulation
+enabled = true
+# Specify the Stacks block height to fork from
+initial_height = 3491155
+use_mainnet_wallets = true

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -6,6 +6,11 @@ telemetry = false
 cache_dir = './.cache'
 requirements = []
 
+[contracts.annotations_test]
+path = "tests/contracts/generator-tests/annotations_test.clar"
+clarity_version = 3
+epoch = "3.1"
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -4,7 +4,10 @@ description = ''
 authors = []
 telemetry = false
 cache_dir = './.cache'
-requirements = []
+requirements = [
+    { contract_id = "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd001-direct-execute"},
+    { contract_id = "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip024-miamicoin-signal-vote"}
+]
 
 [contracts.annotations_test]
 path = "tests/contracts/generator-tests/annotations_test.clar"
@@ -13,6 +16,11 @@ epoch = "3.1"
 
 [contracts.annotations_flow_test]
 path = "tests/contracts/generator-tests/annotations_flow_test.clar"
+clarity_version = 3
+epoch = "3.1"
+
+[contracts.contract_call_flow_test]
+path = "tests/contracts/generator-tests/contract-call_flow_test.clar"
 clarity_version = 3
 epoch = "3.1"
 

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -60,6 +60,11 @@ plan:
     - id: 0
       transactions:
         - emulated-contract-publish:
+            contract-name: annotations_flow_test
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: tests/contracts/generator-tests/annotations_flow_test.clar
+            clarity-version: 3
+        - emulated-contract-publish:
             contract-name: annotations_test
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: tests/contracts/generator-tests/annotations_test.clar

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -1,80 +1,90 @@
----
 id: 0
-name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+name: Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`
 network: simnet
 genesis:
   wallets:
-    - name: deployer
-      address: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: faucet
-      address: SPNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2C69MJD9
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_1
-      address: SP1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2XG1V316
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_2
-      address: SP2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CH94GRJ
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_3
-      address: SP2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1J5QKA2F
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_4
-      address: SP2NEB84ASENDXKYGJPQW86YXQCEFEX2ZPB1S2EP
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_5
-      address: SP2REHHS5J3CERCRBEPMGH7921Q6PYKAADR2V8W5C
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_6
-      address: SP3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ3JJEPMJ
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_7
-      address: SP3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXFA1W3C2
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
-    - name: wallet_8
-      address: SP3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N6R5192Q
-      balance: "100000000000000"
-      sbtc-balance: "1000000000"
+  - name: deployer
+    address: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: faucet
+    address: SPNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2C69MJD9
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_1
+    address: SP1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2XG1V316
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_2
+    address: SP2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CH94GRJ
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_3
+    address: SP2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1J5QKA2F
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_4
+    address: SP2NEB84ASENDXKYGJPQW86YXQCEFEX2ZPB1S2EP
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_5
+    address: SP2REHHS5J3CERCRBEPMGH7921Q6PYKAADR2V8W5C
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_6
+    address: SP3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ3JJEPMJ
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_7
+    address: SP3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXFA1W3C2
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
+  - name: wallet_8
+    address: SP3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N6R5192Q
+    balance: '100000000000000'
+    sbtc-balance: '1000000000'
   contracts:
-    - genesis
-    - lockup
-    - bns
-    - cost-voting
-    - costs
-    - pox
-    - costs-2
-    - pox-2
-    - costs-3
-    - pox-3
-    - pox-4
-    - signers
-    - signers-voting
+  - genesis
+  - lockup
+  - bns
+  - cost-voting
+  - costs
+  - pox
+  - costs-2
+  - pox-2
+  - costs-3
+  - pox-3
+  - pox-4
+  - signers
+  - signers-voting
+  - costs-4
 plan:
   batches:
-    - id: 0
-      transactions:
-        - emulated-contract-publish:
-            contract-name: annotations_flow_test
-            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
-            path: tests/contracts/generator-tests/annotations_flow_test.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: annotations_test
-            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
-            path: tests/contracts/generator-tests/annotations_test.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: contract_call_flow_test
-            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
-            path: tests/contracts/generator-tests/contract-call_flow_test.clar
-            clarity-version: 3
-      epoch: "3.1"
+  - id: 0
+    transactions:
+    - transaction-type: emulated-contract-publish
+      contract-name: annotations_flow_test
+      emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+      path: tests/contracts/generator-tests/annotations_flow_test.clar
+      clarity-version: 3
+    - transaction-type: emulated-contract-publish
+      contract-name: annotations_test
+      emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+      path: tests/contracts/generator-tests/annotations_test.clar
+      clarity-version: 3
+    - transaction-type: emulated-contract-publish
+      contract-name: contract_call_flow_test
+      emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+      path: tests/contracts/generator-tests/contract-call_flow_test.clar
+      clarity-version: 3
+    - transaction-type: emulated-contract-publish
+      contract-name: some-contract
+      emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+      path: tests/contracts/some-contract.clar
+      clarity-version: 3
+    - transaction-type: emulated-contract-publish
+      contract-name: list-args_flow_test
+      emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
+      path: tests/contracts/generator-tests/list-args_flow_test.clar
+      clarity-version: 3
+    epoch: '3.1'

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -56,4 +56,12 @@ genesis:
     - cost-voting
     - bns
 plan:
-  batches: []
+  batches:
+    - id: 0
+      transactions:
+        - emulated-contract-publish:
+            contract-name: annotations_test
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: tests/contracts/generator-tests/annotations_test.clar
+            clarity-version: 3
+      epoch: "3.1"

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -60,6 +60,168 @@ plan:
     - id: 0
       transactions:
         - emulated-contract-publish:
+            contract-name: citycoin-core-trait
+            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
+            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.citycoin-core-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: citycoin-token-trait
+            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
+            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.citycoin-token-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: miamicoin-auth
+            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
+            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-auth.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: sip-010-trait-ft-standard
+            emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
+            path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: miamicoin-token
+            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
+            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: extension-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.extension-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: proposal-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.proposal-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: base-dao
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.base-dao.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd001-direct-execute
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd001-direct-execute.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: nft-trait
+            emulated-sender: SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9
+            path: "./.cache/requirements/SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd002-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: stacking-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.stacking-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd002-treasury-mia-stacking
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-stacking.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd002-treasury-nyc-stacking
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-nyc-stacking.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd003-user-registry
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd003-user-registry.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd004-city-registry
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd004-city-registry.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd005-city-data
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd005-city-data.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd007-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd007-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: citycoin-token-v2-trait
+            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
+            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-token-v2-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: citycoin-core-v2-trait
+            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
+            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-core-v2-trait.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: newyorkcitycoin-auth-v2
+            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
+            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-auth-v2.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: newyorkcitycoin-auth
+            emulated-sender: SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5
+            path: "./.cache/requirements/SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5.newyorkcitycoin-auth.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: newyorkcitycoin-token
+            emulated-sender: SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5
+            path: "./.cache/requirements/SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5.newyorkcitycoin-token.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: newyorkcitycoin-token-v2
+            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
+            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: miamicoin-auth-v2
+            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
+            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-auth-v2.clar"
+            clarity-version: 1
+      epoch: "2.1"
+    - id: 1
+      transactions:
+        - emulated-contract-publish:
+            contract-name: miamicoin-core-v1-patch
+            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
+            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-core-v1-patch.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: miamicoin-token-v2
+            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
+            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2.clar"
+            clarity-version: 1
+        - emulated-contract-publish:
+            contract-name: ccd007-citycoin-stacking
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd007-citycoin-stacking.clar"
+            clarity-version: 1
+      epoch: "2.1"
+    - id: 2
+      transactions:
+        - emulated-contract-publish:
+            contract-name: ccip015-trait
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip015-trait.clar"
+            clarity-version: 2
+      epoch: "2.4"
+    - id: 3
+      transactions:
+        - emulated-contract-publish:
+            contract-name: ccip024-miamicoin-signal-vote
+            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
+            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip024-miamicoin-signal-vote.clar"
+            clarity-version: 2
+      epoch: "2.5"
+    - id: 4
+      transactions:
+        - emulated-contract-publish:
             contract-name: annotations_flow_test
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: tests/contracts/generator-tests/annotations_flow_test.clar
@@ -68,5 +230,10 @@ plan:
             contract-name: annotations_test
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: tests/contracts/generator-tests/annotations_test.clar
+            clarity-version: 3
+        - emulated-contract-publish:
+            contract-name: contract_call_flow_test
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: tests/contracts/generator-tests/contract-call_flow_test.clar
             clarity-version: 3
       epoch: "3.1"

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -5,235 +5,76 @@ network: simnet
 genesis:
   wallets:
     - name: deployer
-      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      address: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: faucet
-      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      address: SPNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2C69MJD9
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_1
-      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      address: SP1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2XG1V316
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_2
-      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      address: SP2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CH94GRJ
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_3
-      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      address: SP2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1J5QKA2F
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_4
-      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      address: SP2NEB84ASENDXKYGJPQW86YXQCEFEX2ZPB1S2EP
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_5
-      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      address: SP2REHHS5J3CERCRBEPMGH7921Q6PYKAADR2V8W5C
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_6
-      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      address: SP3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ3JJEPMJ
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_7
-      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      address: SP3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXFA1W3C2
       balance: "100000000000000"
       sbtc-balance: "1000000000"
     - name: wallet_8
-      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      address: SP3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N6R5192Q
       balance: "100000000000000"
       sbtc-balance: "1000000000"
   contracts:
+    - genesis
+    - lockup
+    - bns
+    - cost-voting
     - costs
     - pox
+    - costs-2
     - pox-2
+    - costs-3
     - pox-3
     - pox-4
-    - lockup
-    - costs-2
-    - costs-3
-    - cost-voting
-    - bns
+    - signers
+    - signers-voting
 plan:
   batches:
     - id: 0
       transactions:
         - emulated-contract-publish:
-            contract-name: citycoin-core-trait
-            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
-            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.citycoin-core-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: citycoin-token-trait
-            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
-            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.citycoin-token-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: miamicoin-auth
-            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
-            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-auth.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: sip-010-trait-ft-standard
-            emulated-sender: SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
-            path: "./.cache/requirements/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: miamicoin-token
-            emulated-sender: SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27
-            path: "./.cache/requirements/SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: extension-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.extension-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: proposal-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.proposal-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: base-dao
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.base-dao.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd001-direct-execute
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd001-direct-execute.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: nft-trait
-            emulated-sender: SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9
-            path: "./.cache/requirements/SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd002-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: stacking-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.stacking-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd002-treasury-mia-stacking
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-stacking.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd002-treasury-nyc-stacking
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-nyc-stacking.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd003-user-registry
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd003-user-registry.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd004-city-registry
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd004-city-registry.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd005-city-data
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd005-city-data.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd007-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd007-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: citycoin-token-v2-trait
-            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
-            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-token-v2-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: citycoin-core-v2-trait
-            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
-            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.citycoin-core-v2-trait.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: newyorkcitycoin-auth-v2
-            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
-            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-auth-v2.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: newyorkcitycoin-auth
-            emulated-sender: SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5
-            path: "./.cache/requirements/SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5.newyorkcitycoin-auth.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: newyorkcitycoin-token
-            emulated-sender: SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5
-            path: "./.cache/requirements/SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5.newyorkcitycoin-token.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: newyorkcitycoin-token-v2
-            emulated-sender: SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11
-            path: "./.cache/requirements/SPSCWDV3RKV5ZRN1FQD84YE1NQFEDJ9R1F4DYQ11.newyorkcitycoin-token-v2.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: miamicoin-auth-v2
-            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
-            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-auth-v2.clar"
-            clarity-version: 1
-      epoch: "2.1"
-    - id: 1
-      transactions:
-        - emulated-contract-publish:
-            contract-name: miamicoin-core-v1-patch
-            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
-            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-core-v1-patch.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: miamicoin-token-v2
-            emulated-sender: SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R
-            path: "./.cache/requirements/SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2.clar"
-            clarity-version: 1
-        - emulated-contract-publish:
-            contract-name: ccd007-citycoin-stacking
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd007-citycoin-stacking.clar"
-            clarity-version: 1
-      epoch: "2.1"
-    - id: 2
-      transactions:
-        - emulated-contract-publish:
-            contract-name: ccip015-trait
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip015-trait.clar"
-            clarity-version: 2
-      epoch: "2.4"
-    - id: 3
-      transactions:
-        - emulated-contract-publish:
-            contract-name: ccip024-miamicoin-signal-vote
-            emulated-sender: SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH
-            path: "./.cache/requirements/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip024-miamicoin-signal-vote.clar"
-            clarity-version: 2
-      epoch: "2.5"
-    - id: 4
-      transactions:
-        - emulated-contract-publish:
             contract-name: annotations_flow_test
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
             path: tests/contracts/generator-tests/annotations_flow_test.clar
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: annotations_test
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
             path: tests/contracts/generator-tests/annotations_test.clar
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: contract_call_flow_test
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            emulated-sender: SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R
             path: tests/contracts/generator-tests/contract-call_flow_test.clar
             clarity-version: 3
       epoch: "3.1"

--- a/example/package.json
+++ b/example/package.json
@@ -13,13 +13,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "3.1.0",
+    "@stacks/clarinet-sdk": "3.9.1",
     "@stacks/clarunit": "^0.1.0",
     "@stacks/transactions": "^7.1.0",
     "chokidar-cli": "^3.0.0",
-    "typescript": "^5.8.3",
-    "vite": "^7.0.0",
-    "vitest": "^3.2.4",
-    "vitest-environment-clarinet": "^2.3.0"
+    "typescript": "^5.9.3",
+    "vite": "^7.2.2",
+    "vitest": "^4.0.8",
+    "vitest-environment-clarinet": "^3.0.1"
   }
 }

--- a/example/tests/my-contract_test.clar
+++ b/example/tests/my-contract_test.clar
@@ -7,6 +7,7 @@
   )
 )
 
+;; @caller 'ST000000000000000000002AMW42H
 (define-public (test-a-times-b2)
   (begin
     (asserts! (is-eq (ok u108) (contract-call? .my-contract a-times-b u9 u12))

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -20,7 +20,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "node_modules/@stacks/clarinet-sdk/vitest-helpers/src",
     "tests"
   ]
 }

--- a/example/vitest.config.js
+++ b/example/vitest.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 import {
   vitestSetupFilePath,
   getClarinetVitestsArgv,
-} from "@hirosystems/clarinet-sdk/vitest";
+} from "@stacks/clarinet-sdk/vitest";
 
 /*
   In this file, Vitest is configured so that it works seamlessly with Clarinet and the Simnet.

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   },
   "homepage": "https://github.com/stacks-network/clarunit#readme",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "3.1.0",
+    "@hirosystems/clarinet-sdk": "3.7.0",
     "@stacks/common": "^7.0.2",
-    "@stacks/transactions": "7.1.0",
+    "@stacks/transactions": "7.2.0",
     "chokidar-cli": "^3.0.0",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "6.3.5",
     "vitest": "3.2.3",
     "vitest-environment-clarinet": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
   },
   "homepage": "https://github.com/stacks-network/clarunit#readme",
   "dependencies": {
-    "@hirosystems/clarinet-sdk": "3.7.0",
-    "@stacks/common": "^7.0.2",
-    "@stacks/transactions": "7.2.0",
+    "@stacks/clarinet-sdk": "3.15.1",
+    "@stacks/common": "^7.3.1",
+    "@stacks/transactions": "7.4.0",
     "chokidar-cli": "^3.0.0",
-    "typescript": "5.9.2",
-    "vite": "6.3.5",
-    "vitest": "3.2.3",
-    "vitest-environment-clarinet": "2.3.0"
+    "typescript": "6.0.2",
+    "vite": "8.0.3",
+    "vitest": "4.1.2",
+    "vitest-environment-clarinet": "3.0.2"
   },
   "devDependencies": {
-    "fast-check": "4.1.1"
+    "fast-check": "4.6.0"
   }
 }

--- a/src/clarunit-flow-generator.ts
+++ b/src/clarunit-flow-generator.ts
@@ -1,4 +1,4 @@
-import { ParsedTransactionResult, tx } from "@hirosystems/clarinet-sdk";
+import { ParsedTransactionResult, tx } from "@stacks/clarinet-sdk";
 import * as fs from "fs";
 import { describe, it } from "vitest";
 import {

--- a/src/clarunit-flow-generator.ts
+++ b/src/clarunit-flow-generator.ts
@@ -8,6 +8,7 @@ import {
   extractTestAnnotationsAndCalls,
 } from "./parser/clarity-parser-flow-tests";
 import { expectOk, isValidTestFunction } from "./parser/test-helpers";
+import { getCaller } from "./clarunit-utils";
 import path from "path";
 
 /**
@@ -100,9 +101,7 @@ function mineBlocksFromFunctionBody(
     const mineBlocksBefore =
       parseInt(callAnnotations["mine-blocks-before"] as string) || 0;
     // get caller address
-    const caller = accounts.get(
-      (callAnnotations["caller"] as string) || "deployer"
-    )!;
+    const caller = getCaller(callAnnotations, accounts);
 
     if (mineBlocksBefore >= 1) {
       if (blockStarted) {

--- a/src/clarunit-generator.ts
+++ b/src/clarunit-generator.ts
@@ -56,10 +56,10 @@ export function generateUnitTests(simnet: Simnet) {
             delete functionAnnotations.prepare;
 
           // handle caller address for this test
-          const callerAddress = functionAnnotations.caller
-            ? annotations.caller[0] === "'"
-              ? `${(annotations.caller as string).substring(1)}`
-              : accounts.get(annotations.caller)!
+          const callerAddress = functionAnnotations.caller && typeof functionAnnotations.caller === "string"
+            ? functionAnnotations.caller[0] === "'"
+              ? `${(functionAnnotations.caller as string).substring(1)}`
+              : accounts.get(functionAnnotations.caller)!
             : accounts.get("deployer")!;
 
           if (functionAnnotations.prepare) {

--- a/src/clarunit-generator.ts
+++ b/src/clarunit-generator.ts
@@ -1,4 +1,4 @@
-import { Simnet, tx } from "@hirosystems/clarinet-sdk";
+import { Simnet, tx } from "@stacks/clarinet-sdk";
 import { describe, it } from "vitest";
 import { extractTestAnnotations } from "./parser/clarity-parser";
 import { expectOkTrue, isValidTestFunction } from "./parser/test-helpers";

--- a/src/clarunit-generator.ts
+++ b/src/clarunit-generator.ts
@@ -1,15 +1,13 @@
 import { Simnet, tx } from "@hirosystems/clarinet-sdk";
 import { describe, it } from "vitest";
-import {
-  extractTestAnnotations,
-} from "./parser/clarity-parser";
+import { extractTestAnnotations } from "./parser/clarity-parser";
 import { expectOkTrue, isValidTestFunction } from "./parser/test-helpers";
 import { FunctionAnnotations } from "./parser/clarity-parser-flow-tests";
 
 /**
  * Returns true if the contract is a test contract
  * @param contractName name of the contract
- * @returns 
+ * @returns
  */
 function isTestContract(contractName: string) {
   return (
@@ -44,10 +42,11 @@ export function generateUnitTests(simnet: Simnet) {
           annotations[functionName] || {};
 
         const mineBlocksBefore =
-          parseInt(annotations["mine-blocks-before"] as string) || 0;
+          parseInt(functionAnnotations["mine-blocks-before"] as string) || 0;
 
-        const testDescription = `${functionCall.name}${functionAnnotations.name ? `: ${functionAnnotations.name}` : ""
-          }`;
+        const testDescription = `${functionCall.name}${
+          functionAnnotations.name ? `: ${functionAnnotations.name}` : ""
+        }`;
         it(testDescription, () => {
           // handle prepare function for this test
           if (hasDefaultPrepareFunction && !functionAnnotations.prepare)
@@ -56,11 +55,13 @@ export function generateUnitTests(simnet: Simnet) {
             delete functionAnnotations.prepare;
 
           // handle caller address for this test
-          const callerAddress = functionAnnotations.caller && typeof functionAnnotations.caller === "string"
-            ? functionAnnotations.caller[0] === "'"
-              ? `${(functionAnnotations.caller as string).substring(1)}`
-              : accounts.get(functionAnnotations.caller)!
-            : accounts.get("deployer")!;
+          const callerAddress =
+            functionAnnotations.caller &&
+            typeof functionAnnotations.caller === "string"
+              ? functionAnnotations.caller[0] === "'"
+                ? `${(functionAnnotations.caller as string).substring(1)}`
+                : accounts.get(functionAnnotations.caller)!
+              : accounts.get("deployer")!;
 
           if (functionAnnotations.prepare) {
             // mine block with prepare function call

--- a/src/clarunit-generator.ts
+++ b/src/clarunit-generator.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { extractTestAnnotations } from "./parser/clarity-parser";
 import { expectOkTrue, isValidTestFunction } from "./parser/test-helpers";
 import { FunctionAnnotations } from "./parser/clarity-parser-flow-tests";
+import { getCaller } from "./clarunit-utils";
 
 /**
  * Returns true if the contract is a test contract
@@ -55,13 +56,7 @@ export function generateUnitTests(simnet: Simnet) {
             delete functionAnnotations.prepare;
 
           // handle caller address for this test
-          const callerAddress =
-            functionAnnotations.caller &&
-            typeof functionAnnotations.caller === "string"
-              ? functionAnnotations.caller[0] === "'"
-                ? `${(functionAnnotations.caller as string).substring(1)}`
-                : accounts.get(functionAnnotations.caller)!
-              : accounts.get("deployer")!;
+          const callerAddress = getCaller(functionAnnotations, accounts);
 
           if (functionAnnotations.prepare) {
             // mine block with prepare function call

--- a/src/clarunit-utils.ts
+++ b/src/clarunit-utils.ts
@@ -1,0 +1,7 @@
+export const getCaller = (annotations: any, accounts: Map<string, string>) => {
+  return annotations.caller && typeof annotations.caller === "string"
+    ? annotations.caller[0] === "'"
+      ? `${(annotations.caller as string).substring(1)}`
+      : accounts.get(annotations.caller)!
+    : accounts.get("deployer")!;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { generateUnitTests } from "./clarunit-generator";
 import { generateFlowTests } from "./clarunit-flow-generator";
-import { Simnet } from "@hirosystems/clarinet-sdk";
+import { Simnet } from "@stacks/clarinet-sdk";
 
 export function clarunit(simnet: Simnet) {
 	generateUnitTests(simnet);

--- a/src/parser/clarity-parser-flow-tests.ts
+++ b/src/parser/clarity-parser-flow-tests.ts
@@ -163,10 +163,10 @@ function extractUnwrapInfo(
       fn = {
         args: (callAnnotations["type-hints"] as string)
           .split(",")
-          .map((s) => ({ type: s.trim() })),
+          .map((s) => ({ type: parseTypeHint(s.trim()) })),
       };
     } else {
-      throw `function ${functionName} not found in contract ${contractName} and not type-hints provided`;
+      throw `function ${functionName} of ${contractName} not found in Clarinet toml and no type-hints provided`;
     }
   }
   const args = fn.args.map((arg: any, index: number) =>
@@ -219,4 +219,47 @@ function splitArgs(argString: string): string[] {
   }
 
   return splitArgs;
+}
+
+/**
+ * Parse type hint string into ContractInterfaceAtomType
+ * @param typeHint string like "uint128", "(optional uint128)", etc.
+ * @returns ContractInterfaceAtomType
+ */
+function parseTypeHint(typeHint: string): any {
+  typeHint = typeHint.trim();
+
+  // Handle parentheses wrapped types like (optional uint128)
+  if (typeHint.startsWith("(") && typeHint.endsWith(")")) {
+    const inner = typeHint.slice(1, -1).trim();
+    const parts = inner.split(" ");
+
+    if (parts[0] === "optional") {
+      return {
+        optional: parseTypeHint(parts.slice(1).join(" ")),
+      };
+    }
+
+    // Add other complex type handling as needed
+  }
+
+  // Handle simple types
+  switch (typeHint) {
+    case "uint":
+    case "uint128":
+      return "uint128";
+    case "int":
+    case "int128":
+      return "int128";
+    case "bool":
+      return "bool";
+    case "principal":
+      return "principal";
+    case "trait_reference":
+      return "trait_reference";
+    case "none":
+      return "none";
+    default:
+      throw new Error(`Unsupported type hint: ${typeHint}`);
+  }
 }

--- a/src/parser/clarity-parser-flow-tests.ts
+++ b/src/parser/clarity-parser-flow-tests.ts
@@ -114,7 +114,7 @@ export function extractContractCalls(lastFunctionBody: string, simnet: Simnet) {
       if (prop) callAnnotations[prop] = value ?? true;
     }
     // try to extract call info from (unwrap! (contract-call? ...))
-    let callInfo = extractUnwrapInfo(call, simnet);
+    let callInfo = extractUnwrapInfo(call, simnet, callAnnotations);
     if (!callInfo) {
       // try to extract call info from (try! (my-function))
       callInfo = extractTryInfo(call);
@@ -133,9 +133,13 @@ export function extractContractCalls(lastFunctionBody: string, simnet: Simnet) {
  * @param statement
  * @returns
  */
-function extractUnwrapInfo(statement: string, simnet: Simnet): CallInfo | null {
+function extractUnwrapInfo(
+  statement: string,
+  simnet: Simnet,
+  callAnnotations: FunctionAnnotations
+): CallInfo | null {
   const match = statement.match(
-    /\(unwrap! \(contract-call\? (?:\.(.+?)|'(.+?)) (.+?)(( .+?)*)\)/
+    /\(unwrap!\s+\(contract-call\?\s+(?:\.(.+?)|'(.+?))\s+(.+?)((\s+.+?)*)\)/m
   );
   if (!match) return null;
   // match[1] is the contract address,
@@ -155,7 +159,15 @@ function extractUnwrapInfo(statement: string, simnet: Simnet): CallInfo | null {
     }
   });
   if (!fn) {
-    throw `function ${functionName} not found in contract ${contractName}`;
+    if (callAnnotations["type-hints"]) {
+      fn = {
+        args: (callAnnotations["type-hints"] as string)
+          .split(",")
+          .map((s) => ({ type: s.trim() })),
+      };
+    } else {
+      throw `function ${functionName} not found in contract ${contractName} and not type-hints provided`;
+    }
   }
   const args = fn.args.map((arg: any, index: number) =>
     stringToCV(argStrings[index], arg.type)

--- a/src/parser/clarity-parser-flow-tests.ts
+++ b/src/parser/clarity-parser-flow-tests.ts
@@ -138,16 +138,37 @@ function extractUnwrapInfo(
   simnet: Simnet,
   callAnnotations: FunctionAnnotations
 ): CallInfo | null {
+  // Match contract-call header only (contract + function name).
+  // Args are extracted separately using balanced-paren counting
+  // to avoid catastrophic backtracking with nested list/tuple args.
   const match = statement.match(
-    /\(unwrap!\s+\(contract-call\?\s+(?:\.(.+?)|'(.+?))\s+(.+?)((\s+.+?)*)\)/m
+    /\(unwrap!\s+\(contract-call\?\s+(?:\.(\S+)|'(\S+))\s+(\S+)/m
   );
   if (!match) return null;
+
+  // Find args: everything between the function name and the balanced
+  // closing paren of (contract-call? ...)
+  const headerEnd = match.index! + match[0].length;
+  let depth = 2; // we're inside (unwrap! (contract-call? ...
+  let contractCallClose = -1;
+  for (let i = headerEnd; i < statement.length; i++) {
+    if (statement[i] === "(") depth++;
+    if (statement[i] === ")") depth--;
+    if (depth === 1) {
+      // found closing ) of (contract-call? ...)
+      contractCallClose = i;
+      break;
+    }
+  }
+  if (contractCallClose === -1) return null;
+  const argsRaw = statement.slice(headerEnd, contractCallClose);
+
   // match[1] is the contract address,
   const [contractAddress, contractName] = match[2]
     ? match[2].split(".")
     : [simnet.deployer, match[1]];
   const functionName = match[3];
-  const argStrings = splitArgs(match[4]);
+  const argStrings = splitArgs(argsRaw);
   let fn: any;
   simnet.getContractsInterfaces().forEach((contract, contractFQN) => {
     const [ctrAddress, ctrName] = contractFQN.split(".");
@@ -208,8 +229,9 @@ function splitArgs(argString: string): string[] {
     if (char === "(") rbrackets++;
     if (char === ")") rbrackets--;
 
+    const isWhitespace = char === " " || char === "\n" || char === "\t" || char === "\r";
     const atLastChar = i === argString.length - 1;
-    if ((char === " " && brackets === 0 && rbrackets === 0) || atLastChar) {
+    if ((isWhitespace && brackets === 0 && rbrackets === 0) || atLastChar) {
       const newArg = argString.slice(argStart, i + (atLastChar ? 1 : 0));
       if (newArg.trim()) {
         splitArgs.push(newArg.trim());

--- a/src/parser/string-to-cv.ts
+++ b/src/parser/string-to-cv.ts
@@ -63,6 +63,8 @@ export function stringToCV(
       return { type: "uint", value: Cl.uint(arg.slice(1)) };
     case "int128":
       return { type: "int", value: Cl.int(arg) };
+    case "bool":
+      return { type: "bool", value: Cl.bool(arg === "true") };
     case "principal":
       const [address, name] = arg.split(".");
       return name
@@ -73,14 +75,15 @@ export function stringToCV(
               value: Cl.contractPrincipal(simnet.deployer, name),
             }
         : { type: "principal", value: Cl.standardPrincipal(address) };
-    case "bool":
-      return { type: "bool", value: Cl.bool(arg === "true") };
     case "trait_reference":
-      console.log("trait_reference", arg);
       const [addressTrait, nameTrait] = arg.split(".");
       return {
         type: "trait_reference",
-        value: Cl.contractPrincipal(addressTrait.substring(1), nameTrait),
+        value: Cl.contractPrincipal(
+          // handle both fully qualified contract ids and .contract-name
+          addressTrait.length > 1 ? addressTrait.substring(1) : simnet.deployer,
+          nameTrait
+        ),
       };
   }
   const typeDescriptor = Object.keys(type)[0];
@@ -118,7 +121,7 @@ export function stringToCV(
         };
       }
     default:
-      throw new Error(`Unsupported type ${type}`);
+      throw new Error(`Unsupported type ${arg}, ${typeDescriptor}`);
   }
 }
 

--- a/src/parser/string-to-cv.ts
+++ b/src/parser/string-to-cv.ts
@@ -75,6 +75,13 @@ export function stringToCV(
         : { type: "principal", value: Cl.standardPrincipal(address) };
     case "bool":
       return { type: "bool", value: Cl.bool(arg === "true") };
+    case "trait_reference":
+      console.log("trait_reference", arg);
+      const [addressTrait, nameTrait] = arg.split(".");
+      return {
+        type: "trait_reference",
+        value: Cl.contractPrincipal(addressTrait.substring(1), nameTrait),
+      };
   }
   const typeDescriptor = Object.keys(type)[0];
   switch (typeDescriptor) {

--- a/src/parser/string-to-cv.ts
+++ b/src/parser/string-to-cv.ts
@@ -120,6 +120,31 @@ export function stringToCV(
           ),
         };
       }
+    case "list": {
+      const listType = (type as { list: { type: ContractInterfaceAtomType; length: number } }).list;
+      // strip outer (list ... )
+      const inner = arg.replace(/^\(list\s*/, "").replace(/\)$/, "").trim();
+      if (!inner) {
+        return { type: "list", value: Cl.list([]) };
+      }
+      // split list elements respecting nested parens/braces
+      const elements: string[] = [];
+      let start = 0;
+      let depth = 0;
+      for (let i = 0; i < inner.length; i++) {
+        if (inner[i] === "(" || inner[i] === "{") depth++;
+        if (inner[i] === ")" || inner[i] === "}") depth--;
+        if ((inner[i] === " " && depth === 0) || i === inner.length - 1) {
+          const el = inner.slice(start, i + (i === inner.length - 1 ? 1 : 0)).trim();
+          if (el) elements.push(el);
+          start = i + 1;
+        }
+      }
+      const values = elements.map(
+        (el) => stringToCV(el, listType.type).value
+      );
+      return { type: "list", value: Cl.list(values) };
+    }
     default:
       throw new Error(`Unsupported type ${arg}, ${typeDescriptor}`);
   }

--- a/src/parser/test-helpers.ts
+++ b/src/parser/test-helpers.ts
@@ -1,4 +1,4 @@
-import { ParsedTransactionResult } from "@hirosystems/clarinet-sdk";
+import { ParsedTransactionResult } from "@stacks/clarinet-sdk";
 import { Cl, ClarityType, cvToString } from "@stacks/transactions";
 import { expect } from "vitest";
 

--- a/tests/clarity-parser-flow.test.ts
+++ b/tests/clarity-parser-flow.test.ts
@@ -31,7 +31,10 @@ describe("verify clarity parser for flow tests", () => {
       },
     });
     expect(callInfos["test-simple-flow"][2]).toEqual({
-      callAnnotations: { caller: "wallet_1" },
+      callAnnotations: {
+        caller: "wallet_1",
+        "type-hints": "principal, (optional uint)",
+      },
       callInfo: {
         args: [
           {
@@ -39,7 +42,7 @@ describe("verify clarity parser for flow tests", () => {
             value: {
               type: "contract",
               value:
-                "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox4-self-service-multi",
+                "SP1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R.pox4-self-service-multi",
             },
           },
           {

--- a/tests/clarity-parser-flow.test.ts
+++ b/tests/clarity-parser-flow.test.ts
@@ -8,9 +8,9 @@ describe("verify clarity parser for flow tests", () => {
     const [annotations, callInfos] = extractTestAnnotationsAndCalls(
       fs.readFileSync(
         path.join(__dirname, "./contracts/parser-tests/simple-flow.clar"),
-        "utf8"
+        "utf8",
       ),
-      simnet
+      simnet,
     );
     expect(annotations["test-simple-flow"]).toEqual({});
     // check the two function calls
@@ -70,9 +70,9 @@ describe("verify clarity parser for flow tests", () => {
     const [annotations, callInfos] = extractTestAnnotationsAndCalls(
       fs.readFileSync(
         path.join(__dirname, "./contracts/parser-tests/bad-flow.clar"),
-        "utf8"
+        "utf8",
       ),
-      simnet
+      simnet,
     );
     expect(annotations["test-bad-flow"]).toEqual({});
     expect(callInfos["test-bad-flow"][0]).toEqual({
@@ -84,5 +84,18 @@ describe("verify clarity parser for flow tests", () => {
       },
     });
     expect(callInfos["test-bad-flow"].length).toEqual(1);
+  });
+
+  //assertion in clarity-parser-flow.test.ts verifying that:
+  // callInfo.args[0] is a list of two buffer values
+  // callInfo.args[1] is a list of two bool values
+  it("should parse list types and arguments across lines", () => {
+    const [annotations, callInfos] = extractTestAnnotationsAndCalls(
+      fs.readFileSync(
+        path.join(__dirname, "./contracts/parser-tests/bad-flow.clar"),
+        "utf8",
+      ),
+      simnet,
+    );
   });
 });

--- a/tests/clarity-parser-flow.test.ts
+++ b/tests/clarity-parser-flow.test.ts
@@ -53,6 +53,14 @@ describe("verify clarity parser for flow tests", () => {
         functionName: "allow-contract-caller",
       },
     });
+    expect(callInfos["test-simple-flow"][3]).toEqual({
+      callAnnotations: { caller: "'ST000000000000000000002AMW42H" },
+      callInfo: {
+        args: [],
+        contractName: "",
+        functionName: "my-test-function",
+      },
+    });
   });
 
   it("should parse flow test with bad annotations", () => {

--- a/tests/clarity-parser-string-to-cv.test.ts
+++ b/tests/clarity-parser-string-to-cv.test.ts
@@ -1,13 +1,16 @@
+import { Cl, ClarityType } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
-import { stringToCV } from "../src/parser/string-to-cv";
-import { ClarityType, intCV, stringUtf8CV, uintCV } from "@stacks/transactions";
+import {
+  ContractInterfaceAtomType,
+  stringToCV,
+} from "../src/parser/string-to-cv";
 
 describe("verify string to cv conversion", () => {
   it("should convert string to cv", () => {
     const result = stringToCV("hello", { "string-utf8": { length: 100 } });
     expect(result).toEqual({
       type: "string",
-      value: stringUtf8CV("hello"),
+      value: Cl.stringUtf8("hello"),
     });
   });
 
@@ -15,7 +18,7 @@ describe("verify string to cv conversion", () => {
     const result = stringToCV("u12345", "uint128");
     expect(result).toEqual({
       type: "uint",
-      value: uintCV(12345),
+      value: Cl.uint(12345),
     });
   });
 
@@ -25,7 +28,61 @@ describe("verify string to cv conversion", () => {
     });
     expect(result).toEqual({
       type: "tuple",
-      value: { value: { a: intCV(12345) }, type: ClarityType.Tuple },
+      value: { value: { a: Cl.int(12345) }, type: ClarityType.Tuple },
     });
+  });
+
+  it("should convert list of uints to cv", () => {
+    const result = stringToCV("(list u1 u2 u3)", {
+      list: { type: "uint128", length: 3 },
+    });
+    expect(result).toEqual({
+      type: "list",
+      value: {
+        value: [Cl.uint(1), Cl.uint(2), Cl.uint(3)],
+        type: ClarityType.List,
+      },
+    });
+  });
+
+  it("should convert list of tuples to cv", () => {
+    const result = stringToCV("(list {a: u1} {a: u2} {a: u3})", {
+      list: { type: { tuple: [{ name: "a", type: "uint128" }] }, length: 3 },
+    });
+    expect(result).toEqual({
+      type: "list",
+      value: {
+        value: [
+          { value: { a: Cl.uint(1) }, type: ClarityType.Tuple },
+          { value: { a: Cl.uint(2) }, type: ClarityType.Tuple },
+          { value: { a: Cl.uint(3) }, type: ClarityType.Tuple },
+        ],
+        type: ClarityType.List,
+      },
+    });
+  });
+
+  it("should parse list arguments", () => {
+    // single-element buffer list
+    const bufListType = {
+      list: { type: { buffer: { length: 32 } }, length: 1 },
+    };
+    expect(
+      stringToCV(
+        "(list 0x43f51785937b153496e1bd092a4999405d697138273681aba55e841756043fe2)",
+        bufListType,
+      ).value,
+    ).toEqual(Cl.list([Cl.bufferFromHex("43f51785937b153496e1bd092a4999405d697138273681aba55e841756043fe2")]));
+
+    // boolean list
+    const boolListType = {
+      list: { type: "bool" as ContractInterfaceAtomType, length: 2 },
+    };
+    expect(stringToCV("(list true false)", boolListType).value).toEqual(
+      Cl.list([Cl.bool(true), Cl.bool(false)]),
+    );
+
+    // empty list
+    expect(stringToCV("(list)", boolListType).value).toEqual(Cl.list([]));
   });
 });

--- a/tests/clarity-parser.test.ts
+++ b/tests/clarity-parser.test.ts
@@ -46,6 +46,10 @@ describe("verify clarity parser", () => {
       "mine-before": "20",
       name: "all annotation test 2",
     });
+
+    expect(result["test-all-annotations-3"]).toEqual({
+      caller: "'ST000000000000000000002AMW42H",
+    });
   });
 
   it("should parse with bad annotations", () => {

--- a/tests/clarunit.test.ts
+++ b/tests/clarunit.test.ts
@@ -1,0 +1,3 @@
+import { clarunit } from "../src/index";
+
+clarunit(simnet);

--- a/tests/clarunit.test.ts
+++ b/tests/clarunit.test.ts
@@ -1,3 +1,2 @@
 import { clarunit } from "../src/index";
-
 clarunit(simnet);

--- a/tests/contracts/generator-tests/annotations_flow_test.clar
+++ b/tests/contracts/generator-tests/annotations_flow_test.clar
@@ -12,8 +12,8 @@
 
 (define-public (assert-block-height-3)
   (begin
-    (asserts! (is-eq u3 stacks-block-height)
-      (err (concat "expected block height 3, found "
+    (asserts! (is-eq u3491158 stacks-block-height)
+      (err (concat "expected block height 3491158, found "
         (int-to-ascii stacks-block-height)
       ))
     )
@@ -23,8 +23,8 @@
 
 (define-public (assert-block-height-13)
   (begin
-    (asserts! (is-eq u13 stacks-block-height)
-      (err (concat "expected block height 13, found "
+    (asserts! (is-eq u3491168 stacks-block-height)
+      (err (concat "expected block height 3491168, found "
         (int-to-ascii stacks-block-height)
       ))
     )

--- a/tests/contracts/generator-tests/annotations_flow_test.clar
+++ b/tests/contracts/generator-tests/annotations_flow_test.clar
@@ -1,0 +1,33 @@
+;; @name test block height at launch
+(define-public (test-block-height-at-launch)
+  (begin
+    ;; @caller wallet_1
+    (try! (assert-block-height-3))
+    ;; @mine-blocks-before 10
+    ;; @caller wallet_1
+    (try! (assert-block-height-13))
+    (ok true)
+  )
+)
+
+(define-public (assert-block-height-3)
+  (begin
+    (asserts! (is-eq u3 stacks-block-height)
+      (err (concat "expected block height 3, found "
+        (int-to-ascii stacks-block-height)
+      ))
+    )
+    (ok true)
+  )
+)
+
+(define-public (assert-block-height-13)
+  (begin
+    (asserts! (is-eq u13 stacks-block-height)
+      (err (concat "expected block height 13, found "
+        (int-to-ascii stacks-block-height)
+      ))
+    )
+    (ok true)
+  )
+)

--- a/tests/contracts/generator-tests/annotations_flow_test.clar
+++ b/tests/contracts/generator-tests/annotations_flow_test.clar
@@ -1,7 +1,7 @@
 ;; @name test block height at launch
 (define-public (test-block-height-at-launch)
   (begin
-    ;; @caller wallet_1
+    ;; @caller 'SP1T91N2Y2TE5M937FE3R6DE0HGWD85SGCV50T95A
     (try! (assert-block-height-3))
     ;; @mine-blocks-before 10
     ;; @caller wallet_1

--- a/tests/contracts/generator-tests/annotations_test.clar
+++ b/tests/contracts/generator-tests/annotations_test.clar
@@ -2,8 +2,8 @@
 ;; One block is need to advance to epoch 2.5
 (define-public (test-block-height-at-launch)
   (begin
-    (asserts! (is-eq u3 stacks-block-height)
-      (err (concat "expected block height 3, found "
+    (asserts! (is-eq u3491158 stacks-block-height)
+      (err (concat "expected block height 3491158, found "
         (int-to-ascii stacks-block-height)
       ))
     )
@@ -14,8 +14,8 @@
 ;; @mine-blocks-before 10
 (define-public (test-mine-blocks-before)
   (begin
-    (asserts! (is-eq u13 stacks-block-height)
-      (err (concat "expected block height 13, found "
+    (asserts! (is-eq u3491168 stacks-block-height)
+      (err (concat "expected block height 3491168, found "
         (int-to-ascii stacks-block-height)
       ))
     )
@@ -26,10 +26,10 @@
 ;; @caller wallet_1
 (define-public (test-caller)
   (begin
-    (asserts! (is-eq tx-sender 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)
+    (asserts! (is-eq tx-sender 'SP1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2XG1V316)
       (err tx-sender)
     )
-    (asserts! (is-eq contract-caller 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)
+    (asserts! (is-eq contract-caller 'SP1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2XG1V316)
       (err contract-caller)
     )
     (ok true)

--- a/tests/contracts/generator-tests/annotations_test.clar
+++ b/tests/contracts/generator-tests/annotations_test.clar
@@ -1,0 +1,27 @@
+
+;; test block-height at launch
+;; One block is need to advance to epoch 2.5
+(define-public (test-block-height-at-launch)
+    (begin
+        (asserts! (is-eq u3 stacks-block-height) (err (concat "expected block height 3, found " (int-to-ascii stacks-block-height))))
+        (ok true)))
+
+;; @mine-blocks-before 10
+(define-public (test-mine-blocks-before)
+    (begin
+        (asserts! (is-eq u13 stacks-block-height) (err (concat "expected block height 13, found " (int-to-ascii stacks-block-height))))
+        (ok true)))
+
+;; @caller wallet_1
+(define-public (test-caller)
+    (begin
+        (asserts! (is-eq tx-sender 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5) (err tx-sender))
+        (asserts! (is-eq contract-caller 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5) (err contract-caller))
+        (ok true)))
+
+;; @caller 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
+(define-public (test-caller-2)
+    (begin
+        (asserts! (is-eq tx-sender 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE) (err tx-sender))
+        (asserts! (is-eq contract-caller 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE) (err contract-caller))
+        (ok true)))

--- a/tests/contracts/generator-tests/annotations_test.clar
+++ b/tests/contracts/generator-tests/annotations_test.clar
@@ -1,27 +1,50 @@
-
 ;; test block-height at launch
 ;; One block is need to advance to epoch 2.5
 (define-public (test-block-height-at-launch)
-    (begin
-        (asserts! (is-eq u3 stacks-block-height) (err (concat "expected block height 3, found " (int-to-ascii stacks-block-height))))
-        (ok true)))
+  (begin
+    (asserts! (is-eq u3 stacks-block-height)
+      (err (concat "expected block height 3, found "
+        (int-to-ascii stacks-block-height)
+      ))
+    )
+    (ok true)
+  )
+)
 
 ;; @mine-blocks-before 10
 (define-public (test-mine-blocks-before)
-    (begin
-        (asserts! (is-eq u13 stacks-block-height) (err (concat "expected block height 13, found " (int-to-ascii stacks-block-height))))
-        (ok true)))
+  (begin
+    (asserts! (is-eq u13 stacks-block-height)
+      (err (concat "expected block height 13, found "
+        (int-to-ascii stacks-block-height)
+      ))
+    )
+    (ok true)
+  )
+)
 
 ;; @caller wallet_1
 (define-public (test-caller)
-    (begin
-        (asserts! (is-eq tx-sender 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5) (err tx-sender))
-        (asserts! (is-eq contract-caller 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5) (err contract-caller))
-        (ok true)))
+  (begin
+    (asserts! (is-eq tx-sender 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)
+      (err tx-sender)
+    )
+    (asserts! (is-eq contract-caller 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)
+      (err contract-caller)
+    )
+    (ok true)
+  )
+)
 
 ;; @caller 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE
 (define-public (test-caller-2)
-    (begin
-        (asserts! (is-eq tx-sender 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE) (err tx-sender))
-        (asserts! (is-eq contract-caller 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE) (err contract-caller))
-        (ok true)))
+  (begin
+    (asserts! (is-eq tx-sender 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE)
+      (err tx-sender)
+    )
+    (asserts! (is-eq contract-caller 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE)
+      (err contract-caller)
+    )
+    (ok true)
+  )
+)

--- a/tests/contracts/generator-tests/contract-call_flow_test.clar
+++ b/tests/contracts/generator-tests/contract-call_flow_test.clar
@@ -1,0 +1,16 @@
+;; @name test external contract call
+(define-public (test-contract-call)
+  (begin
+    ;; @caller 'SP7DGES13508FHRWS1FB0J3SZA326FP6QRMB6JDE
+    ;; @type-hints trait_reference
+    (unwrap!
+      (contract-call?
+        'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd001-direct-execute
+        direct-execute
+        'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip024-miamicoin-signal-vote
+      )
+      (err "direct execute failed")
+    )
+    (ok true)
+  )
+)

--- a/tests/contracts/generator-tests/list-args_flow_test.clar
+++ b/tests/contracts/generator-tests/list-args_flow_test.clar
@@ -1,0 +1,15 @@
+;; @name test list args in flow test
+(define-public (test-list-args)
+  (begin
+    ;; @caller wallet_1
+    (unwrap!
+      (contract-call? .some-contract
+        fn-with-list-args
+        (list 0xdeadbeef 0xcafebabe)
+        (list true false)
+      )
+      (err "failed")
+    )
+    (ok true)
+  )
+)

--- a/tests/contracts/parser-tests/all-annotations.clar
+++ b/tests/contracts/parser-tests/all-annotations.clar
@@ -11,3 +11,7 @@
 ;; @caller wallet_2
 (define-public (test-all-annotations-2)
     (ok true))
+
+;; @caller 'ST000000000000000000002AMW42H
+(define-public (test-all-annotations-3)
+    (ok true))

--- a/tests/contracts/parser-tests/simple-flow.clar
+++ b/tests/contracts/parser-tests/simple-flow.clar
@@ -6,6 +6,7 @@
         ;; @caller wallet_2
         (try! (my-test-function2))
         ;; @caller wallet_1
+        ;; @type-hints principal, (optional uint)
         (unwrap! (contract-call? 'ST000000000000000000002AMW42H.pox-4 allow-contract-caller .pox4-self-service-multi none) (err "allow-contract-caller failed"))
         ;; @caller 'ST000000000000000000002AMW42H
         (try! (my-test-function))

--- a/tests/contracts/parser-tests/simple-flow.clar
+++ b/tests/contracts/parser-tests/simple-flow.clar
@@ -7,6 +7,8 @@
         (try! (my-test-function2))
         ;; @caller wallet_1
         (unwrap! (contract-call? 'ST000000000000000000002AMW42H.pox-4 allow-contract-caller .pox4-self-service-multi none) (err "allow-contract-caller failed"))
+        ;; @caller 'ST000000000000000000002AMW42H
+        (try! (my-test-function))
         (ok true)))
 
 (define-public (my-test-function)

--- a/tests/contracts/some-contract.clar
+++ b/tests/contracts/some-contract.clar
@@ -1,0 +1,3 @@
+(define-public (fn-with-list-args (arg1 (list 10 (buff 10))) (arg2 (list 10 bool)))
+  (ok true)
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "node_modules/@stacks/clarinet-sdk/vitest-helpers/src",
     "tests"
   ]
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,7 +5,7 @@ import { configDefaults } from "vitest/config";
 import {
   vitestSetupFilePath,
   getClarinetVitestsArgv,
-} from "@hirosystems/clarinet-sdk/vitest";
+} from "@stacks/clarinet-sdk/vitest";
 
 /*
   In this file, Vitest is configured so that it works seamlessly with Clarinet and the Simnet.
@@ -13,7 +13,7 @@ import {
   The `vitest-environment-clarinet` will initialise the clarinet-sdk
   and make the `simnet` object available globally in the test files.
 
-  `vitestSetupFilePath` points to a file in the `@hirosystems/clarinet-sdk` package that does two things:
+  `vitestSetupFilePath` points to a file in the `@stacks/clarinet-sdk` package that does two things:
     - run `before` hooks to initialize the simnet and `after` hooks to collect costs and coverage reports.
     - load custom vitest matchers to work with Clarity values (such as `expect(...).toBeUint()`)
 
@@ -26,8 +26,9 @@ export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, "example/**"],
     environment: "clarinet", // use vitest-environment-clarinet
-    pool: "forks",
+    pool: "threads",
     poolOptions: {
+      threads: { singleThread: true },
       forks: { singleFork: true },
     },
     setupFiles: [


### PR DESCRIPTION
This PR
* fixes #19 
* fixes #8 
* adds tests for caller annotation using addresses

The example fails until a new npm package was released